### PR TITLE
feat: Add Augment Code IDE support with multi-location installation options

### DIFF
--- a/bmad-core/data/bmad-kb.md
+++ b/bmad-core/data/bmad-kb.md
@@ -102,6 +102,7 @@ npx bmad-method install
   - **Cline**: VS Code extension with AI features
   - **Roo Code**: Web-based IDE with agent support
   - **GitHub Copilot**: VS Code extension with AI peer programming assistant
+  - **Augment Code**: AI-powered development environment
 
 **Note for VS Code Users**: BMAD-METHOD™ assumes when you mention "VS Code" that you're using it with an AI-powered extension like GitHub Copilot, Cline, or Roo. Standard VS Code without AI capabilities cannot run BMad agents. The installer includes built-in support for Cline and Roo.
 

--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -475,6 +475,38 @@ async function promptInstallation() {
     answers.githubCopilotConfig = { configChoice };
   }
 
+  // Configure Augment Code immediately if selected
+  if (ides.includes('augment-code')) {
+    console.log(chalk.cyan('\n📍 Augment Code Location Configuration'));
+    console.log(chalk.dim('Choose where to install BMad agents for Augment Code access.\n'));
+
+    const { selectedLocations } = await inquirer.prompt([
+      {
+        type: 'checkbox',
+        name: 'selectedLocations',
+        message: 'Select Augment Code command locations:',
+        choices: [
+          {
+            name: 'User Commands (Global): Available across all your projects (user-wide)',
+            value: 'user',
+          },
+          {
+            name: 'Workspace Commands (Project): Stored in repository, shared with team',
+            value: 'workspace',
+          },
+        ],
+        validate: (selected) => {
+          if (selected.length === 0) {
+            return 'Please select at least one location';
+          }
+          return true;
+        },
+      },
+    ]);
+
+    answers.augmentCodeConfig = { selectedLocations };
+  }
+
   // Ask for web bundles installation
   const { includeWebBundles } = await inquirer.prompt([
     {

--- a/tools/installer/bin/bmad.js
+++ b/tools/installer/bin/bmad.js
@@ -49,7 +49,7 @@ program
   .option('-d, --directory <path>', 'Installation directory')
   .option(
     '-i, --ide <ide...>',
-    'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, qwen-code, github-copilot, other)',
+    'Configure for specific IDE(s) - can specify multiple (cursor, claude-code, windsurf, trae, roo, kilo, cline, gemini, qwen-code, github-copilot, augment-code, other)',
   )
   .option(
     '-e, --expansion-packs <packs...>',
@@ -406,6 +406,7 @@ async function promptInstallation() {
           { name: 'Qwen Code', value: 'qwen-code' },
           { name: 'Crush', value: 'crush' },
           { name: 'Github Copilot', value: 'github-copilot' },
+          { name: 'Augment Code', value: 'augment-code' },
         ],
       },
     ]);

--- a/tools/installer/config/install.config.yaml
+++ b/tools/installer/config/install.config.yaml
@@ -121,3 +121,22 @@ ide-configurations:
       # 2. It concatenates all agent files into a single QWEN.md file.
       # 3. Simply mention the agent in your prompt (e.g., "As *dev, ...").
       # 4. The Qwen Code CLI will automatically have the context for that agent.
+
+  augment-code:
+    name: Augment Code
+    format: multi-location
+    locations:
+      user:
+        name: User Commands (Global)
+        rule-dir: ~/.augment/commands/bmad/
+        description: Available across all your projects (user-wide)
+      workspace:
+        name: Workspace Commands (Project)
+        rule-dir: ./.augment/commands/bmad/
+        description: Stored in your repository and shared with your team
+    command-suffix: .md
+    instructions: |
+      # To use BMad agents in Augment Code:
+      # 1. Type /agent-name (e.g., "/dev", "/pm", "/architect")
+      # 2. The agent will adopt that persona for the conversation
+      # 3. Commands are available based on your selected location(s)

--- a/tools/installer/lib/installer.js
+++ b/tools/installer/lib/installer.js
@@ -408,7 +408,12 @@ class Installer {
     if (ides.length > 0) {
       for (const ide of ides) {
         spinner.text = `Setting up ${ide} integration...`;
-        const preConfiguredSettings = ide === 'github-copilot' ? config.githubCopilotConfig : null;
+        let preConfiguredSettings = null;
+        if (ide === 'github-copilot') {
+          preConfiguredSettings = config.githubCopilotConfig;
+        } else if (ide === 'augment-code') {
+          preConfiguredSettings = config.augmentCodeConfig;
+        }
         await ideSetup.setup(ide, installDir, config.agent, spinner, preConfiguredSettings);
       }
     }


### PR DESCRIPTION
## 🚀 Feature: Augment Code IDE Integration

This PR adds comprehensive support for **Augment Code** as a supported IDE in the BMAD Method installer, enabling users to access BMad agents through Augment Code's custom command system.

### ✨ What's New
- **Augment Code - Auggie CLI**: https://docs.augmentcode.com/cli/overview
- **Multi-location Installation**: Users can choose where to install Augment Code commands:
  - **User Commands** (`~/.augment/commands/bmad/`): Global, user-wide access across all projects
  - **Workspace Commands** (`./.augment/commands/bmad/`): Project-specific, team-shared commands

- **Interactive Setup**: Enhanced installer with checkbox selection for multiple installation locations
- **Proper Path Handling**: Automatic tilde expansion and relative path resolution
- **Documentation Updates**: Updated knowledge base and team files to include Augment Code

### DEMO:
[BMAD-METHOD - Augment Code integration Demo](https://www.loom.com/share/e5e877f7921244b2a5e3dbd5735002f6)

### 🔧 Technical Changes

#### Core Implementation
- Added `augment-code` to supported IDE list in CLI help and interactive prompts
- Implemented `setupAugmentCode()` method with location selection logic
- Enhanced IDE configuration with multi-location support structure
- Added proper error handling and validation for location selection

#### Configuration Updates
- **`tools/installer/config/install.config.yaml`**: Added Augment Code configuration with location options
- **`tools/installer/bin/bmad.js`**: Updated CLI help text and interactive choices
- **`tools/installer/lib/ide-setup.js`**: Added setup method and switch case
- **`bmad-core/data/bmad-kb.md`**: Updated documentation with Augment Code support

### 🎯 Usage

Users can now:
1. Run `bmad install --ide augment-code` or select "Augment Code" in interactive mode
2. Choose installation locations (can select multiple):
   - User Commands (Global) - Available across all projects
   - Workspace Commands (Project) - Stored in repository, shared with team
3. Access agents via `/agent-name` slash commands (e.g., `/dev`, `/pm`, `/architect`)

### 🧪 Testing

- ✅ CLI help text displays Augment Code in supported IDE list
- ✅ Interactive installer shows Augment Code as selectable option
- ✅ Multi-location selection prompt works correctly
- ✅ Files are properly installed to selected locations
- ✅ Path resolution works for both user and workspace directories
- ✅ Lint and formatting checks pass

### 📚 Documentation

Updated all relevant documentation files to include Augment Code in the supported IDE lists, ensuring consistency across the codebase.

### 🔄 Backward Compatibility

This change is fully backward compatible - existing installations and IDE configurations remain unaffected.

---

**Ready for review and merge!** 🎉

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author